### PR TITLE
creates staging dataset for development

### DIFF
--- a/studio/sanity.json
+++ b/studio/sanity.json
@@ -7,6 +7,7 @@
     "projectId": "is8j72h6",
     "dataset": "production"
   },
+
   "plugins": [
     "@sanity/base",
     "@sanity/components",
@@ -17,7 +18,10 @@
   ],
   "env": {
     "development": {
-      "plugins": ["@sanity/vision"]
+      "plugins": ["@sanity/vision"],
+      "api": {
+        "dataset": "staging"
+      }
     }
   },
   "parts": [


### PR DESCRIPTION
When running sanity start (for local development), the development environment is used. When running the output of sanity build or sanity deploy, the production environment is used.

You can also override this by setting an env variable when running the script, see here for more info:
https://www.sanity.io/docs/studio-environment-variables